### PR TITLE
Add Monasca support

### DIFF
--- a/fluentd-daemonset-monasca.yaml
+++ b/fluentd-daemonset-monasca.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluentd
+  namespace: kube-system
+  labels:
+    k8s-app: fluentd-logging
+    version: v1
+spec:
+  selector:
+    matchLabels:
+      k8s-app: fluentd-logging
+      version: v1
+  template:
+    metadata:
+      labels:
+        k8s-app: fluentd-logging
+        version: v1
+    spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: fluentd
+        image: fluent/fluentd-kubernetes-daemonset:v1-debian-monasca
+        env:
+          - name:  FLUENT_MONASCA_KEYSTONE_URL
+            value: ""
+          - name:  FLUENT_MONASCA_LOG_API_URL
+            value: ""
+          - name:  FLUENT_USER
+            value: ""
+          - name:  FLUENT_PASSWORD
+            value: ""
+          - name:  FLUENT_DOMAIN_ID
+            value: "default"
+          - name:  FLUENT_MONASCA_PROJECT_NAME
+            value: "magnum-cluster-1"
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers

--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -28,8 +28,11 @@ ENV GEM_HOME /fluentd/vendor/bundle/ruby/2.6.0
 # skip runtime bundler installation
 ENV FLUENTD_DISABLE_BUNDLER_INJECTION 1
 
+ARG monasca_output_plugin_tag=1.0.1
+ARG monasca_output_plugin_url=https://github.com/monasca/fluentd-monasca/archive/$monasca_output_plugin_tag.tar.gz
+
 COPY Gemfile* /fluentd/
-RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev<% if target == "graylog" %> build-essential patch zlib1g-dev liblzma-dev<% elsif target == "kafka" || target == "kafka2" %> build-essential autoconf automake libtool pkg-config<% end %><% if requires_git %> git<% end %>" \
+RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev<% if target == "graylog" %> build-essential patch zlib1g-dev liblzma-dev<% elsif target == "kafka" || target == "kafka2" %> build-essential autoconf automake libtool pkg-config<% elsif target == "monasca" %> curl<% end %><% if requires_git %> git<% end %>" \
   runtimeDeps="<% if target == "kafka" || target == "kafka2" %>krb5-kdc libsasl2-modules-gssapi-mit libsasl2-dev<% elsif target == "azureblob" %>pkg-config libxslt-dev libxml2-dev<% end %>" \
      <% if target == "kafka" || target == "kafka2" %> && export DEBIAN_FRONTEND=noninteractive <% end %> && apt-get update \
      && apt-get upgrade -y \
@@ -39,6 +42,14 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev<% if target == "graylog" %>
     && gem install bundler --version 2.1.4 \
     && bundle config silence_root_warning true<% if target == "azureblob" %> && bundle config build.nokogiri --use-system-libraries<% end %> \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
+<% if target == "monasca" %>
+    && curl -sSL $monasca_output_plugin_url -o /tmp/fluentd-monasca.tar.gz \
+    && tar -xvf /tmp/fluentd-monasca.tar.gz -C /tmp \
+    && cd /tmp/fluentd-monasca-* \
+    && gem build fluentd-monasca-output.gemspec \
+    && gem install fluentd-monasca-output-*.gem \
+    && rm -rf /tmp/fluentd* \
+<% end %>
     && SUDO_FORCE_REMOVE=yes \
     apt-get purge -y --auto-remove \
                   -o APT::AutoRemove::RecommendsImportant=false \

--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -57,6 +57,26 @@
      retry_forever true
    </buffer>
 </match>
+<%  when "monasca" %>
+<match **>
+   @type monasca
+   keystone_url "#{ENV['FLUENT_MONASCA_KEYSTONE_URL']}"
+   monasca_api "#{ENV['FLUENT_MONASCA_LOG_API_URL']}"
+   monasca_api_version v2.0
+   username "#{ENV['FLUENT_MONASCA_USER'] || use_default}"
+   password "#{ENV['FLUENT_MONASCA_PASSWORD'] || use_default}"
+   domain_id "{#{ENV['FLUENT_MONASCA_DOMAIN_ID'] || 'default'}}"
+   project_name "{#{ENV['FLUENT_MONASCA_PROJECT_NAME'] || 'magnum'}}"
+   message_field_name "{#{ENV['FLUENT_MONASCA_MESSAGE_FIELD'] || 'Payload'}}"
+   <buffer>
+     flush_thread_count "#{ENV['FLUENT_MONASCA_BUFFER_FLUSH_THREAD_COUNT'] || '8'}"
+     flush_interval "#{ENV['FLUENT_MONASCA_BUFFER_FLUSH_INTERVAL'] || '5s'}"
+     chunk_limit_size "#{ENV['FLUENT_MONASCA_BUFFER_CHUNK_LIMIT_SIZE'] || '8M'}"
+     queue_limit_length "#{ENV['FLUENT_MONASCA_BUFFER_QUEUE_LIMIT_LENGTH'] || '32'}"
+     retry_max_interval "#{ENV['FLUENT_MONASCA_BUFFER_RETRY_MAX_INTERVAL'] || '30'}"
+     retry_forever true
+   </buffer>
+</match>
 <%  when "logentries"%>
 <match **>
    @type logentries


### PR DESCRIPTION
Build the plugin from source until a gem is published.

Build all files with:

$ make src-all

Can edit the list in the Makefile to change what gets built

Then build the Docker image with:

$ make image DOCKERFILE=v1.11/debian-monasca VERSION=1.0.0

Currently there are some issues with removing ruby sources. You can work around these
by removing that section in the generated Dockerfile.